### PR TITLE
Add "ui" container to test setup to allow running the UI in a server.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+web/node_modules
+web/dist

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site
 node_modules
 web/dist
 web/build
+.local

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,36 @@
+# Building openvpn-aws
+
+There are two parts to openvpn-aws, a server written in Go, and static web UI written in JavaScript and compiled with npm/rollup.
+
+## Building the server
+
+As shown in the `Dockerfile`, the server can be built normally with go, though this is only useful for development, as the
+final package is a Docker image.
+
+Dependencies:
+- go 1.13
+- git
+- ssh
+
+```
+go get github.com/amadigan/openvpn-aws
+cd github.com/amadigan/openvpn-aws
+go build ./...
+```
+
+## Building the client
+See the README.md in web/
+
+## Building with Docker
+Dependencies:
+- docker
+
+From the **root** of the repository, run:
+
+```
+docker build -t openvpn-aws -f build/Dockerfile .
+```
+
+The Docker build has two parts, first using `golang:1-alpine`, it builds the server binary. The commands in the first section
+are ordered to maximize build caching. The final image is built from alpine, and the only installed dependency is `openvpn`
+itself.

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - zeus:/mnt/zeus
       - plato:/mnt/plato
       - hercules:/mnt/hercules
+      - ui:/mnt/ui
 
   mars:
     build: www
@@ -68,6 +69,15 @@ services:
       - server:/mnt/vpn
     command: ["--local", "/mnt/vpn"]
 
+  ui:
+    build:
+      context: ..
+      dockerfile: test/ui/Dockerfile
+    volumes:
+      - ../web/.local/tls:/srv/tls
+      - ui:/mnt/ui
+    ports:
+      - "443"
 
 networks:
   firewall:
@@ -84,3 +94,4 @@ volumes:
   zeus:
   plato:
   hercules:
+  ui:

--- a/test/generator/generator.sh
+++ b/test/generator/generator.sh
@@ -86,3 +86,4 @@ fi
 [ ! -f /mnt/plato/client.crt ] && mkuser plato
 
 cp -r /vpn/* /mnt/server/
+cp -r /mnt/server/ca.crt /mnt/ui/

--- a/test/ui/Dockerfile
+++ b/test/ui/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:12-alpine AS build
+WORKDIR /source
+COPY web/package.json web/package-lock.json ./
+RUN npm install
+COPY web .
+RUN npm run prod
+
+FROM alpine:3.10
+EXPOSE 443
+RUN apk add --no-cache openssl nginx
+COPY test/ui/nginx.conf /etc/nginx/nginx.conf
+COPY test/ui/docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+WORKDIR /srv/www
+COPY --from=build /source/dist/ ./
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/test/ui/docker-entrypoint.sh
+++ b/test/ui/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#! /bin/sh
+mkdir -p /srv/tls
+
+if [ ! -f /srv/tls/ui.crt ]; then
+  openssl ecparam -name secp384r1 -genkey -noout -out /srv/tls/ui.key
+  openssl req -x509 -nodes -days 3650 -key /srv/tls/ui.key -batch -subj "/CN=localhost" -out /srv/tls/ui.crt
+fi
+
+cp -r /mnt/ui/* /srv/www
+
+exec nginx

--- a/test/ui/nginx.conf
+++ b/test/ui/nginx.conf
@@ -1,0 +1,26 @@
+daemon off;
+error_log /dev/stderr;
+pid /dev/null;
+
+events {}
+
+http {
+  include /etc/nginx/mime.types;
+
+  default_type application/octet-stream;
+  sendfile on;
+  ssl_prefer_server_ciphers on;
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                '$status $body_bytes_sent "$http_referer" '
+                '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log /dev/stdout main;
+
+  server {
+    listen 443 default_server ssl http2;
+    root /srv/www;
+    index index.html;
+    ssl_certificate /srv/tls/ui.crt;
+    ssl_certificate_key /srv/tls/ui.key;
+    ssl_protocols TLSv1.3;
+  }
+}

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,38 @@
+# The openvpn-aws UI
+The openvpn-aws UI is a static HTML application for generating keys and certificates for VPN clients. It generates
+RSA keys of a configurable length (4096 bits is recommend, 2048 is faster when testing the client in development).
+
+## Building the client
+From `web/` run:
+
+```
+npm install
+npm run prod
+```
+
+For an un-minified development build, run `npm run dev`. Currently, there is no `serve` or `watch` target.
+
+## Test server
+The test code contains a working SSL server that will serve the UI. The UI uses WebCrypto to generate RSA keys. Unfortunately, Google Chrome has adopted
+a position that is hostile towards developers, preventing the use of WebCrypto unless the page is served over SSL. Note that in Chrome, you will need to go
+to [chrome://flags] and enabled "Allow invalid certificates for resources loaded from localhost.".
+
+### First time setup
+The test code needs to generate some files before it can be used. These are stored in volumes managed by docker-compose.
+
+```
+cd test
+docker-compose build generator
+docker-compose run generator
+```
+
+### Running the UI
+```
+cd test
+docker-compose build ui
+docker-compse up ui
+```
+
+The UI server will start on a randomly assigned port, which you can determine by running `docker ps`. On first run, a self-signed certificate and key will
+be written to `web/.local/tls`. This key will be used by the server every time, so if you need to add a particular certificate to your OS, you should only
+need to do it once.

--- a/web/src/jsdt.js
+++ b/web/src/jsdt.js
@@ -211,7 +211,6 @@ export class JSDT extends TagLib {
   }
 
   static exec(el, template, ...args) {
-    let start = Date.now();
     let root = new JSDT();
     let rv = template.apply(root, args);
 
@@ -227,12 +226,6 @@ export class JSDT extends TagLib {
       for (let load of root.$load) {
         load.apply(el);
       }
-    }
-
-    let renderTime = Date.now() - start;
-
-    if (renderTime > 0) {
-      console.log('Render time: ' + renderTime + ' ms');
     }
 
     return rv;


### PR DESCRIPTION
This also removes render time logging from JSDT and adds some more documentation.